### PR TITLE
Fix service transformation

### DIFF
--- a/pkg/kubernetes/transformations.go
+++ b/pkg/kubernetes/transformations.go
@@ -84,7 +84,8 @@ func UpdateRoleBindingSVCACCTNamespace(newNamespace string, numberOfSubjects int
 
 func RemoveServiceClusterIPs() jsonpatch.Patch {
 	patchJSON := fmt.Sprintf(`[
-{"op": "remove", "path": "/spec/clusterIP"}
+{"op": "remove", "path": "/spec/clusterIP"},
+{"op": "remove", "path": "/spec/clusterIPs"}
 ]`)
 	patch, err := jsonpatch.DecodePatch([]byte(patchJSON))
 	if err != nil {


### PR DESCRIPTION
Error importing services:
`Service \"user\" is invalid: spec.clusterIPs: Invalid value: []string{\"172.30.125.100\"}: must be empty when clusterIP is empty", "Error from server (Invalid): error when creating \"/home/jason/Documents/openshift/src/github.com/water-hole/crane-batch-migration/output/robot-shop/Service_robot-shop_web.yaml\": Service \"web\" is invalid: spec.clusterIPs: Invalid value: []string{\"172.30.23.160\"}: must be empty when clusterIP is empty"]`