### PR TITLE
do not delete admin rolebinding

### DIFF
--- a/pkg/transform/transforms.go
+++ b/pkg/transform/transforms.go
@@ -218,8 +218,7 @@ func openshiftWhiteOuts(file TransformFile, u unstructured.Unstructured) bool {
 		return true
 	}
 	// Assume if from/to openshift that the admin rolebinding is already created for the user.
-	if u.GetName() == "admin" ||
-		u.GetName() == "system:image-builders" ||
+	if u.GetName() == "system:image-builders" ||
 		u.GetName() == "system:image-pullers" ||
 		u.GetName() == "system:deployers" {
 		if u.GetObjectKind().GroupVersionKind().GroupKind() == AOS3RoleBindingGK ||


### PR DESCRIPTION
Thinking about this:
- imagestream-migrate creates a namespace not a project
- we could switch it to create the admin rolebinding
- the problem is that I think the original rolebinding will contain the user that created the namesapce rather than the admin likely to run the imagestream-migrate playbook.
- Therefore I think it makes sense to continue creating an NS and then restore the admin rolebinding.